### PR TITLE
On API 23+, GET_ACCOUNTS permission is no longer needed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -142,7 +142,8 @@ under the License.
                 android:name="android.content.SyncAdapter"
                 android:resource="@xml/syncadapter"/>
         </service>
-		
+
+        <!-- This receiver is needed for home screen recommendations -->
         <receiver
             android:enabled="true"
             android:name=".BootCompletedReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@ under the License.
     <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA"/>
 
     <!-- Required to use the android AccountManager -->
-    <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" android:maxSdkVersion="22"/>
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS"/>
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS"/>
 

--- a/app/src/main/java/ie/macinnes/tvheadend/account/AccountUtils.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/account/AccountUtils.java
@@ -29,7 +29,9 @@ import android.support.v4.app.ActivityCompat;
 import ie.macinnes.tvheadend.Constants;
 
 public class AccountUtils {
-    // TODO: Supressing warnings is bad...
+    // TODO: Suppressing warnings is bad... But, the Android linter is broken. getAccountsByType
+    // does not require the GET_ACCOUNTS permission, it simply will return other apps accounts if
+    // that permission has been granted. Remove the supression once Android's linter is smarter.
 
     @SuppressLint({"MissingPermission"})
     public static Account getActiveAccount(Context context) {


### PR DESCRIPTION
Leaving this here would normally be harmless, but API 23 / Android 6.0's permission
groups means on 23+ we were asking for "Read All Contacts". This seems like a totally
broken assumption on Googles part. Using Account storage should not require I have
access to your contacts. Cmon!