### PR TITLE
Remove unused travis components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ android:
 
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
-    - sys-img-x86-android-tv-24
+    #- sys-img-x86-android-tv-24
 
 addons:
   artifacts:


### PR DESCRIPTION
Unused components just add extra unnecessary time, let's skip
downloading them.