### PR TITLE
Switch from Firebase to ACRA crash reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 google-services.json
+acra.properties
 /projectFilesBackup/
 
 ## From: https://github.com/github/gitignore/blob/master/Android.gitignore

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,10 @@ android {
         targetSdkVersion 24
         versionCode 48
         versionName '0.2.' + versionCode
-        setProperty("archivesBaseName", "$applicationId.$versionName")
+        setProperty("archivesBaseName", "${applicationId}_${versionName}")
+
+        buildConfigField "boolean", "ACRA_ENABLED", "false"
+        buildConfigField "String", "ACRA_REPORT_URI", "\"\""
     }
 
     buildTypes {
@@ -19,6 +22,13 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+
+            if (rootProject.file("acra.properties").exists()) {
+                buildConfigField "boolean", "ACRA_ENABLED", "true"
+                def acraProperties = new Properties()
+                acraProperties.load(new FileInputStream(rootProject.file("acra.properties")))
+                buildConfigField "String", "ACRA_REPORT_URI", "\"" + acraProperties.report_uri + "\""
+            }
         }
     }
     productFlavors {
@@ -38,12 +48,7 @@ dependencies {
     compile 'com.android.support:support-v4:24.2.1'
     compile 'com.android.support:leanback-v17:24.2.1'
     compile 'com.android.support:preference-leanback-v17:24.2.1'
-    compile 'com.google.firebase:firebase-core:9.8.0'
-    compile 'com.google.firebase:firebase-crash:9.8.0'
     compile 'com.google.android.exoplayer:exoplayer:r1.5.9'
     compile 'de.mrmaffen:vlc-android-sdk:1.9.8'
-}
-
-if (project.file('google-services.json').exists()) {
-    apply plugin: 'com.google.gms.google-services'
+    compile 'ch.acra:acra:4.9.0'
 }

--- a/app/src/debug/java/ie/macinnes/tvheadend/DevTestActivity.java
+++ b/app/src/debug/java/ie/macinnes/tvheadend/DevTestActivity.java
@@ -23,6 +23,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.TextView;
 
+import org.acra.ACRA;
 import org.json.JSONObject;
 
 import ie.macinnes.tvheadend.account.AccountUtils;
@@ -118,6 +119,8 @@ public class DevTestActivity extends Activity {
     }
 
     public void showPreferences(View view) {
+        Exception e = new Exception("Tester 2");
+        ACRA.getErrorReporter().handleException(e);
         startActivity(SettingsActivity.getPreferencesIntent(this));
     }
 
@@ -126,5 +129,10 @@ public class DevTestActivity extends Activity {
         Intent i = new Intent(context, EpgSyncService.class);
         context.stopService(i);
         context.startService(i);
+    }
+
+    public void sendCrashReport(View view) {
+        Exception e = new Exception("Test Crash Report");
+        ACRA.getErrorReporter().handleException(e);
     }
 }

--- a/app/src/debug/res/layout/activity_dev_test.xml
+++ b/app/src/debug/res/layout/activity_dev_test.xml
@@ -71,6 +71,14 @@ under the License.
             android:onClick="restartEpgSyncService"
             android:layout_gravity="center_horizontal"/>
 
+        <Button
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Send Fake Crash Report"
+            android:nestedScrollingEnabled="true"
+            android:onClick="sendCrashReport"
+            android:layout_gravity="center_horizontal"/>
+
     </LinearLayout>
 
     <ScrollView

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,7 @@ under the License.
         android:required="false"/>
 
     <application
+        android:name=".Application"
         android:allowBackup="true"
         android:banner="@drawable/banner"
         android:icon="@mipmap/ic_tv_service"

--- a/app/src/main/java/ie/macinnes/tvheadend/Application.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/Application.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ie.macinnes.tvheadend;
+
+import android.content.Context;
+import android.util.Log;
+
+import org.acra.ACRA;
+import org.acra.config.ACRAConfiguration;
+import org.acra.config.ACRAConfigurationException;
+import org.acra.config.ConfigurationBuilder;
+import org.acra.sender.HttpSender;
+
+public class Application extends android.app.Application {
+    private static final String TAG = Application.class.getName();
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+
+        // Initialize ACRA crash reporting
+        if (BuildConfig.ACRA_ENABLED) {
+            Log.i(TAG, "Initializing ACRA");
+            try {
+                final ACRAConfiguration config = new ConfigurationBuilder(this)
+                        .setHttpMethod(HttpSender.Method.PUT)
+                        .setReportType(HttpSender.Type.JSON)
+                        .setFormUri(BuildConfig.ACRA_REPORT_URI)
+                        .setLogcatArguments("-t", "500", "-v", "time", "*:I")
+                        .setAdditionalSharedPreferences(Constants.PREFERENCE_TVHEADEND)
+                        .setSharedPreferenceName(Constants.PREFERENCE_TVHEADEND)
+                        .setSharedPreferenceMode(Context.MODE_PRIVATE)
+                        .setBuildConfigClass(BuildConfig.class)
+                        .build();
+                ACRA.init(this, config);
+            } catch (ACRAConfigurationException e) {
+                Log.e(TAG, "Failed to init ACRA", e);
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,15 @@ under the License.
     <string name="title_activity_authenticator">TVHeadend Authenticator</string>
     <string name="account_label">TVHeadend</string>
     <string name="title_activity_dev_test">TVH DevTest</string>
+
+    <string name="pref_disable_acra">Enable ACRA?</string>
+    <string name="pref_acra_enabled">ACRA enabled</string>
+    <string name="pref_acra_disabled">ACRA disabled</string>
+
+    <string name="pref_acra_syslog">Send system logs?</string>
+    <string name="pref_acra_syslog_enabled">Sending system logs is enabled</string>
+    <string name="pref_acra_syslog_disabled">Sending system logs is disabled</string>
+
+    <string name="pref_acra_user_email">Contact email address (optional)</string>
+    <string name="pref_acra_user_email_summary">Sometimes, the developers may need to contact you for more info</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -46,4 +46,24 @@
                 android:dependency="vlc_deinterlace_enabled"/>
         </PreferenceScreen>
     </PreferenceCategory>
+
+    <PreferenceCategory android:title="Advanced Settings">
+        <PreferenceScreen android:title="Crash Reporting Settings" android:key="crash_reporting_settings" android:persistent="false">
+            <CheckBoxPreference android:key="acra.enable"
+                                android:title="@string/pref_disable_acra"
+                                android:summaryOn="@string/pref_acra_enabled"
+                                android:summaryOff="@string/pref_acra_disabled"
+                                android:defaultValue="true"/>
+            <CheckBoxPreference android:key="acra.syslog.enable"
+                                android:summaryOn="@string/pref_acra_syslog_enabled"
+                                android:summaryOff="@string/pref_acra_syslog_disabled"
+                                android:title="@string/pref_acra_syslog"
+                                android:defaultValue="true"/>
+            <EditTextPreference android:key="acra.user.email"
+                                android:title="@string/pref_acra_user_email"
+                                android:summary="@string/pref_acra_user_email_summary"/>
+
+        </PreferenceScreen>
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
Firebase/Google crash reporting doesn't include logs, which are HUGELY
valuable when tracing a crash. ARCA is a self hosted crash reporting
server and library, which includes logs.