### PR TITLE
Use BuildConfig.VERSION_NAME rather than PM, to avoid a crash

### DIFF
--- a/app/src/main/java/ie/macinnes/tvheadend/MiscUtils.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/MiscUtils.java
@@ -26,16 +26,6 @@ import java.util.Map;
 
 
 public class MiscUtils {
-    public static String getAppVersionName(Context context) {
-        try {
-            String packageName = context.getPackageName();
-            PackageInfo info = context.getPackageManager().getPackageInfo(packageName, 0);
-            return info.versionName;
-        } catch (PackageManager.NameNotFoundException e) {
-            return "?";
-        }
-    }
-
     public static Map<String, String> createBasicAuthHeader(String username, String password) {
         Map<String, String> headerMap = new HashMap<String, String>();
 

--- a/app/src/main/java/ie/macinnes/tvheadend/account/AuthenticatorActivity.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/account/AuthenticatorActivity.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import ie.macinnes.htsp.Connection;
 import ie.macinnes.htsp.ConnectionListener;
+import ie.macinnes.tvheadend.BuildConfig;
 import ie.macinnes.tvheadend.Constants;
 import ie.macinnes.tvheadend.MiscUtils;
 import ie.macinnes.tvheadend.R;
@@ -351,9 +352,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity {
             final String accountHttpPort = args.getString(Constants.KEY_HTTP_PORT);
             final String accountHttpPath = args.getString(Constants.KEY_HTTP_PATH);
 
-            final String versionName = MiscUtils.getAppVersionName(getActivity().getBaseContext());
-
-            mConnection = new Connection(accountHostname, Integer.parseInt(accountHtspPort), accountName, accountPassword, "android-tvheadend (auth)", versionName);
+            mConnection = new Connection(accountHostname, Integer.parseInt(accountHtspPort), accountName, accountPassword, "android-tvheadend (auth)", BuildConfig.VERSION_NAME);
 
             final ConnectionListener connectionListener = new ConnectionListener() {
                 @Override

--- a/app/src/main/java/ie/macinnes/tvheadend/sync/EpgSyncService.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/sync/EpgSyncService.java
@@ -30,6 +30,7 @@ import java.util.List;
 import ie.macinnes.htsp.Connection;
 import ie.macinnes.htsp.ConnectionListener;
 import ie.macinnes.htsp.tasks.GetFileTask;
+import ie.macinnes.tvheadend.BuildConfig;
 import ie.macinnes.tvheadend.Constants;
 import ie.macinnes.tvheadend.MiscUtils;
 import ie.macinnes.tvheadend.account.AccountUtils;
@@ -135,12 +136,10 @@ public class EpgSyncService extends Service {
         final String username = mAccount.name;
         final String password = mAccountManager.getPassword(mAccount);
 
-        final String versionName = MiscUtils.getAppVersionName(mContext);
-
         // 20971520 = 20MB
         // 10485760 = 10MB
         // 1048576  = 1MB
-        mConnection = new Connection(hostname, port, username, password, "android-tvheadend (epg)", versionName, 100000);
+        mConnection = new Connection(hostname, port, username, password, "android-tvheadend (epg)", BuildConfig.VERSION_NAME, 100000);
 
         ConnectionListener connectionListener = new ConnectionListener() {
             @Override


### PR DESCRIPTION
Some devices seem to crash with "Package manager has died" when we call the
package manager at just the wrong time, so lets not call it.. This is cleaner
anyway.

Fixes #77