### PR TITLE
Fix java.lang.IllegalArgumentException: account is null

### DIFF
--- a/app/src/main/java/ie/macinnes/tvheadend/sync/EpgSyncService.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/sync/EpgSyncService.java
@@ -89,11 +89,25 @@ public class EpgSyncService extends Service {
     @Override
     public void onCreate() {
         Log.i(TAG, "Starting EPG Sync Service");
+
+        mContext = getApplicationContext();
+        mAccountManager = AccountManager.get(mContext);
+        mAccount = AccountUtils.getActiveAccount(mContext);
+
+        if (mAccount == null) {
+            Log.i(TAG, "No account configured, aborting startup of EPG Sync Service");
+            stopSelf();
+            return;
+        }
+
         openConnection();
     }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        if (mAccount == null) {
+            return START_NOT_STICKY;
+        }
         return START_STICKY;
     }
 
@@ -105,15 +119,6 @@ public class EpgSyncService extends Service {
 
     protected void openConnection() {
         mConnectionReady = false;
-
-        mContext = getApplicationContext();
-        mAccountManager = AccountManager.get(mContext);
-        mAccount = AccountUtils.getActiveAccount(mContext);
-
-        if (mAccount == null) {
-            Log.i(TAG, "No account configured, aborting startup of EPG Sync Service");
-            stopSelf();
-        }
 
         initHtspConnection();
 


### PR DESCRIPTION
stopSelf() happens async, we need to return from this. We should also
correctly set the start status flag (START_STICKY vs START_NOT_STICKY)
based on if the service is actually able to do it's thing yet, avoiding
restart loops.