### PR TITLE
Lock around several key HTSP methods

### DIFF
--- a/app/src/main/java/ie/macinnes/tvheadend/account/AuthenticatorActivity.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/account/AuthenticatorActivity.java
@@ -34,7 +34,6 @@ import ie.macinnes.htsp.Connection;
 import ie.macinnes.htsp.ConnectionListener;
 import ie.macinnes.tvheadend.BuildConfig;
 import ie.macinnes.tvheadend.Constants;
-import ie.macinnes.tvheadend.MiscUtils;
 import ie.macinnes.tvheadend.R;
 import ie.macinnes.tvheadend.migrate.MigrateUtils;
 

--- a/app/src/main/java/ie/macinnes/tvheadend/sync/EpgSyncService.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/sync/EpgSyncService.java
@@ -32,7 +32,6 @@ import ie.macinnes.htsp.ConnectionListener;
 import ie.macinnes.htsp.tasks.GetFileTask;
 import ie.macinnes.tvheadend.BuildConfig;
 import ie.macinnes.tvheadend.Constants;
-import ie.macinnes.tvheadend.MiscUtils;
 import ie.macinnes.tvheadend.account.AccountUtils;
 
 public class EpgSyncService extends Service {
@@ -209,8 +208,8 @@ public class EpgSyncService extends Service {
     }
 
     protected void closeConnection() {
-        Log.d(TAG, "Closing HTSP connection");
         if (mConnection != null) {
+            Log.d(TAG, "Closing HTSP connection");
             mConnection.close();
             mConnection = null;
         }


### PR DESCRIPTION
This helps to ensure thread safetey between callers of the connection, and the
connection itself.