### PR TITLE
Add contentType (channel groups based on genres)

### DIFF
--- a/htsp/src/main/java/ie/macinnes/htsp/messages/BaseEventResponse.java
+++ b/htsp/src/main/java/ie/macinnes/htsp/messages/BaseEventResponse.java
@@ -22,6 +22,7 @@ import android.media.tv.TvContentRating;
 import android.media.tv.TvContract;
 import android.os.Build;
 import android.text.TextUtils;
+import android.util.SparseArray;
 
 import ie.macinnes.htsp.HtspMessage;
 import ie.macinnes.htsp.ResponseMessage;
@@ -36,6 +37,7 @@ public class BaseEventResponse extends ResponseMessage {
     protected String mSummary;
     protected String mDescription;
     // Some fields skipped
+    protected int mContentType;
     protected int mAgeRating;
     protected int mSeasonNumber;
     protected int mSeasonCount;
@@ -104,16 +106,24 @@ public class BaseEventResponse extends ResponseMessage {
         return mDescription;
     }
     
+    public void setDescription(String description) {
+        mDescription = description;
+    }
+    
+    public int getContentType() {
+        return mContentType;
+    }
+
+    public void setContentType(int contentType) {
+        mContentType = contentType;
+    }
+    
     public int getAgeRating() {
         return mAgeRating;
     }
 
     public void setAgeRating(int ageRating) {
         mAgeRating = ageRating;
-    }
-
-    public void setDescription(String description) {
-        mDescription = description;
     }
 
     public int getSeasonNumber() {
@@ -168,6 +178,7 @@ public class BaseEventResponse extends ResponseMessage {
         setSummary(htspMessage.getString("summary", null));
         setDescription(htspMessage.getString("description", null));
         // Some fields skipped
+        setContentType(htspMessage.getInt("contentType", INVALID_INT_VALUE));
         setAgeRating(htspMessage.getInt("ageRating", INVALID_INT_VALUE));
         setSeasonNumber(htspMessage.getInt("seasonNumber", INVALID_INT_VALUE));
         setSeasonCount(htspMessage.getInt("seasonCount", INVALID_INT_VALUE));
@@ -177,6 +188,79 @@ public class BaseEventResponse extends ResponseMessage {
         setImage(htspMessage.getString("image", null));
     }
 
+    private static final SparseArray<String> mProgramGenre = new SparseArray<String>() {
+        {
+            append(16, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MOVIES));
+            append(17, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MOVIES));
+            append(18, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MOVIES));
+            append(19, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MOVIES));
+            append(20, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.COMEDY));
+            append(21, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ENTERTAINMENT));
+            append(22, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MOVIES));
+            append(23, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.DRAMA));
+            append(32, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.NEWS));
+            append(33, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.NEWS));
+            append(34, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.NEWS));
+            append(35, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.TECH_SCIENCE));
+            append(48, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ENTERTAINMENT));
+            append(49, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ENTERTAINMENT));
+            append(50, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ENTERTAINMENT));
+            append(51, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ENTERTAINMENT));
+            append(64, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(65, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(66, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(67, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(68, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(69, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(70, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(71, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(72, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(73, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(74, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(75, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SPORTS));
+            append(80, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.FAMILY_KIDS));
+            append(81, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.FAMILY_KIDS));
+            append(82, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.FAMILY_KIDS));
+            append(82, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.FAMILY_KIDS));
+            append(83, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.FAMILY_KIDS));
+            append(84, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.FAMILY_KIDS));
+            append(85, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.FAMILY_KIDS));
+            append(96, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MUSIC));
+            append(97, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MUSIC));
+            append(98, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MUSIC));
+            append(99, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MUSIC));
+            append(100, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MUSIC));
+            append(101, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MUSIC));
+            append(102, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MUSIC));
+            append(112, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ARTS));
+            append(113, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ARTS));
+            append(114, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ARTS));
+            append(115, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ARTS));
+            append(116, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ARTS));
+            append(117, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ARTS));
+            append(118, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MOVIES));
+            append(118, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.MOVIES));
+            append(120, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.NEWS));
+            append(121, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.NEWS));
+            append(122, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ARTS));
+            append(129, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.TECH_SCIENCE));
+            append(144, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.TECH_SCIENCE));
+            append(145, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ANIMAL_WILDLIFE));
+            append(146, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.TECH_SCIENCE));
+            append(147, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.TECH_SCIENCE));
+            append(148, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.TECH_SCIENCE));
+            append(150, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.EDUCATION));
+            append(160, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.LIFE_STYLE));
+            append(161, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.TRAVEL));
+            append(162, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.ARTS));
+            append(163, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.LIFE_STYLE));
+            append(164, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.LIFE_STYLE));
+            append(165, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.LIFE_STYLE));
+            append(166, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.SHOPPING));
+            append(167, TvContract.Programs.Genres.encode(TvContract.Programs.Genres.LIFE_STYLE));
+        }
+    };
+    
     public String toString() {
         return "eventId: " + getEventId();
     }
@@ -214,6 +298,10 @@ public class BaseEventResponse extends ResponseMessage {
         } else if (TextUtils.isEmpty(mSummary) && !TextUtils.isEmpty(mDescription)) {
             // If we have only description, use it.
             values.put(TvContract.Programs.COLUMN_SHORT_DESCRIPTION, mDescription);
+        }
+        
+        if (mContentType != INVALID_INT_VALUE) {
+            values.put(TvContract.Programs.COLUMN_CANONICAL_GENRE, mProgramGenre.get(mContentType));
         }
         
         if (mAgeRating >= 4 && mAgeRating <= 18) {


### PR DESCRIPTION
This adds contentType from Tvheadend (channel groups based on genres DVB ETSI standard).

Some channels sending a genre via EPG OTA (depends on the country). See contentype column in Tvheadend WebUI in the EPG tab.
If you are using a XMLTV source for EPG, you have may to replace/adjust (via a script) the category value in your xmltv file like this:

XMLTV category examples:
`<category lang="en">Movie/Drama</category>`
`<category lang="en">Comedy</category>`
`<category lang="en">News/Current affairs</category>`
`<category lang="en">News/Weather report</category>`

ToDo:
- Multiple genres per event (if wanted)

