### PR TITLE
Allow for disabling of EPG Sync

### DIFF
--- a/app/src/main/java/ie/macinnes/tvheadend/Constants.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/Constants.java
@@ -51,5 +51,6 @@ public class Constants {
     public static final String KEY_DEINTERLACE_METHOD = "vlc_deinterlace_method";
 
     // Session Selection Preference Keys and Values
+    public static final String KEY_EPG_SYNC_ENABLED = "epg_sync_enabled";
     public static final String KEY_EPG_LAST_UPDATE = "EPG_LAST_UPDATE";
 }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -29,6 +29,13 @@
             android:entryValues="@array/video_player_values" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="EPG">
+        <CheckBoxPreference
+            android:key="epg_sync_enabled"
+            android:title="Enabled EPG Sync"
+            android:defaultValue="true" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="Video Player Settings">
         <PreferenceScreen android:title="VLC Settings" android:key="vlc_settings" android:persistent="false">
             <CheckBoxPreference


### PR DESCRIPTION
This is mostly useful for development, in order to avoid an app
restart from flooding the logs with EPG sync logs.