### PR TITLE
Allow disabling of EPG lastUpdate handling

### DIFF
--- a/app/src/main/java/ie/macinnes/tvheadend/Constants.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/Constants.java
@@ -52,5 +52,6 @@ public class Constants {
 
     // Session Selection Preference Keys and Values
     public static final String KEY_EPG_SYNC_ENABLED = "epg_sync_enabled";
-    public static final String KEY_EPG_LAST_UPDATE = "EPG_LAST_UPDATE";
+    public static final String KEY_EPG_LAST_UPDATE_ENABLED = "epg_last_update_enabled";
+    public static final String KEY_EPG_LAST_UPDATE = "EPG_LAST_UPDATE"; // Todo: This name is confusing...
 }

--- a/app/src/main/java/ie/macinnes/tvheadend/sync/EpgSyncTask.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/sync/EpgSyncTask.java
@@ -101,7 +101,12 @@ class EpgSyncTask extends MessageListener {
         EnableAsyncMetadataRequest enableAsyncMetadataRequest = new EnableAsyncMetadataRequest();
         enableAsyncMetadataRequest.setEpgMaxTime(epgMaxTime);
         enableAsyncMetadataRequest.setEpg(true);
-        enableAsyncMetadataRequest.setLastUpdate(lastUpdate);
+
+        if (mSharedPreferences.getBoolean(Constants.KEY_EPG_LAST_UPDATE_ENABLED, true)) {
+            enableAsyncMetadataRequest.setLastUpdate(lastUpdate);
+        } else {
+            Log.d(TAG, "Skipping lastUpdate field, disabled by preference");
+        }
 
         mConnection.sendMessage(enableAsyncMetadataRequest);
     }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -32,7 +32,12 @@
     <PreferenceCategory android:title="EPG">
         <CheckBoxPreference
             android:key="epg_sync_enabled"
-            android:title="Enabled EPG Sync"
+            android:title="Enable EPG Sync"
+            android:defaultValue="true" />
+        <CheckBoxPreference
+            android:key="epg_last_update_enabled"
+            android:title="Enable Last Update Time Optimization"
+            android:summary="Disable if you see gaps in EPG data"
             android:defaultValue="true" />
     </PreferenceCategory>
 


### PR DESCRIPTION
For some users, this results in the EPG having "gaps". Maybe a TVheadend
bug? Maybe our bug? Either way, add a workaround.

Closes #91