### PR TITLE
Remove use of archivesBaseName

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -24,7 +24,7 @@ def publishApkToStore(String trackName) {
     def changeLog = sh(returnStdout: true, script: "./tools/generate-changelog").trim().take(500)
 
     androidApkUpload(
-        apkFilesPattern: 'app/build/outputs/apk/ie.macinnes.tvheadend_*-release.apk',
+        apkFilesPattern: 'app/build/outputs/apk/ie.macinnes.tvheadend-release.apk',
         googleCredentialsId: 'android-tvheadend',
         trackName: trackName,
         recentChangeList: [
@@ -41,7 +41,7 @@ def publishApkToGitHub() {
         [$class: 'StringBinding', credentialsId: '  github-pat-kiall', variable: 'GITHUB_TOKEN'],
     ]) {
         sh(script: "github-release release --user kiall --repo android-tvheadend --tag ${tagName} --name ${tagName} --description '${changeLog}'")
-        sh(script: "github-release upload --user kiall --repo android-tvheadend --tag ${tagName} --name ie.macinnes.tvheadend_${tagName}-release.apk --file app/build/outputs/apk/ie.macinnes.tvheadend_${tagName}-release.apk")
+        sh(script: "github-release upload --user kiall --repo android-tvheadend --tag ${tagName} --name ie.macinnes.tvheadend_${tagName}-release.apk --file app/build/outputs/apk/ie.macinnes.tvheadend-release.apk")
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,9 +15,11 @@ android {
         applicationId "ie.macinnes.tvheadend"
         minSdkVersion project.ext.minSdkVersion
         targetSdkVersion project.ext.targetSdkVersion
+
         versionCode System.getenv("APP_VERSION_CODE") as Integer ?: 0
         versionName gitVersionName
-        setProperty("archivesBaseName", "${applicationId}_${versionName}")
+
+        setProperty("archivesBaseName", applicationId)
 
         buildConfigField "boolean", "ACRA_ENABLED", "false"
         buildConfigField "String", "ACRA_REPORT_URI", "\"\""


### PR DESCRIPTION
Android Studio has a hard time tracking the APKs to use when the name
changes. Long story short, it caches the name when a Gradle Sync is
performed, but generates a different name whenever any git commits
or branch changes etc happens.. The end result is you build, and it'll
upload an old APK to your device until the next Gradle Sync.