### PR TITLE
Fix bug where default preference were not being set

### DIFF
--- a/app/src/main/java/ie/macinnes/tvheadend/migrate/MigrateUtils.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/migrate/MigrateUtils.java
@@ -35,7 +35,8 @@ public class MigrateUtils {
         Log.d(TAG, "doMigrate()");
 
         // Set all default values
-        PreferenceManager.setDefaultValues(context, R.xml.preferences, false);
+        PreferenceManager.setDefaultValues(context, Constants.PREFERENCE_TVHEADEND, Context.MODE_PRIVATE,
+                                           R.xml.preferences, true);
 
         // Store the current version
         int currentApplicationVersion = Constants.MIGRATE_VERSION;


### PR DESCRIPTION
We were setting the preferences into the "Default" preferances file,
rather than the one we actually use. Additionaly, we would only set
the default values once, when new options were added, they weren't
being set.

The way we handle preferences should probably be revisited, as even
this behaviour isn't ideal.