### PR TITLE
HTSP Video: Create StreamReader classes

### DIFF
--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/AacStreamReader.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/AacStreamReader.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.util.MimeTypes;
+
+import java.util.Collections;
+import java.util.List;
+
+import ie.macinnes.htsp.HtspMessage;
+import ie.macinnes.tvheadend.TvhMappings;
+
+public class AacStreamReader extends PlainStreamReader {
+    private static final String TAG = AacStreamReader.class.getName();
+
+    @NonNull
+    @Override
+    protected Format buildFormat(int streamIndex, @NonNull HtspMessage stream) {
+        List<byte[]> initializationData = null;
+
+        if (stream.containsKey("meta")) {
+            initializationData = Collections.singletonList(stream.getByteArray("meta"));
+        }
+
+        int rate = Format.NO_VALUE;
+        if (stream.containsKey("rate")) {
+            rate = TvhMappings.sriToRate(stream.getInteger("rate"));
+        }
+
+        return Format.createAudioSampleFormat(
+                Integer.toString(streamIndex),
+                MimeTypes.AUDIO_AC3,
+                null,
+                Format.NO_VALUE,
+                Format.NO_VALUE,
+                stream.getInteger("channels", Format.NO_VALUE),
+                rate,
+                C.ENCODING_PCM_16BIT,
+                initializationData,
+                null,
+                C.SELECTION_FLAG_AUTOSELECT,
+                stream.getString("language", "und")
+        );
+    }
+}

--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/Ac3StreamReader.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/Ac3StreamReader.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.util.MimeTypes;
+
+import ie.macinnes.htsp.HtspMessage;
+import ie.macinnes.tvheadend.TvhMappings;
+
+public class Ac3StreamReader extends PlainStreamReader {
+
+    @NonNull
+    @Override
+    protected Format buildFormat(int streamIndex, @NonNull HtspMessage stream) {
+        int rate = Format.NO_VALUE;
+        if (stream.containsKey("rate")) {
+            rate = TvhMappings.sriToRate(stream.getInteger("rate"));
+        }
+
+        return Format.createAudioSampleFormat(
+                Integer.toString(streamIndex),
+                MimeTypes.AUDIO_AC3,
+                null,
+                Format.NO_VALUE,
+                Format.NO_VALUE,
+                stream.getInteger("channels", Format.NO_VALUE),
+                rate,
+                C.ENCODING_PCM_16BIT,
+                null,
+                null,
+                C.SELECTION_FLAG_AUTOSELECT,
+                stream.getString("language", "und")
+        );
+    }
+}

--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/Eac3StreamReader.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/Eac3StreamReader.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.util.MimeTypes;
+
+import ie.macinnes.htsp.HtspMessage;
+import ie.macinnes.tvheadend.TvhMappings;
+
+public class Eac3StreamReader extends PlainStreamReader {
+
+    @NonNull
+    @Override
+    protected Format buildFormat(int streamIndex, @NonNull HtspMessage stream) {
+        int rate = Format.NO_VALUE;
+        if (stream.containsKey("rate")) {
+            rate = TvhMappings.sriToRate(stream.getInteger("rate"));
+        }
+
+        return Format.createAudioSampleFormat(
+                Integer.toString(streamIndex),
+                MimeTypes.AUDIO_E_AC3,
+                null,
+                Format.NO_VALUE,
+                Format.NO_VALUE,
+                stream.getInteger("channels", Format.NO_VALUE),
+                rate,
+                C.ENCODING_PCM_16BIT,
+                null,
+                null,
+                C.SELECTION_FLAG_AUTOSELECT,
+                stream.getString("language", "und")
+        );
+    }
+}

--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/H264StreamReader.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/H264StreamReader.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.ParserException;
+import com.google.android.exoplayer2.util.MimeTypes;
+import com.google.android.exoplayer2.util.ParsableByteArray;
+import com.google.android.exoplayer2.video.AvcConfig;
+
+import java.util.List;
+
+import ie.macinnes.htsp.HtspMessage;
+
+public class H264StreamReader extends PlainStreamReader {
+    private static final String TAG = H264StreamReader.class.getName();
+
+    @NonNull
+    @Override
+    protected Format buildFormat(int streamIndex, @NonNull HtspMessage stream) {
+        List<byte[]> initializationData = null;
+
+        if (stream.containsKey("meta")) {
+            try {
+                AvcConfig avcConfig = AvcConfig.parse(new ParsableByteArray(stream.getByteArray("meta")));
+                initializationData = avcConfig.initializationData;
+            } catch (ParserException e) {
+                Log.e(TAG, "Failed to parse H264 meta, discarding");
+            }
+        }
+
+        return Format.createVideoSampleFormat(
+                Integer.toString(streamIndex),
+                MimeTypes.VIDEO_H264,
+                null,
+                Format.NO_VALUE,
+                Format.NO_VALUE,
+                stream.getInteger("width"),
+                stream.getInteger("height"),
+                Format.NO_VALUE,
+                initializationData,
+                null);
+    }
+}

--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/H265StreamReader.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/H265StreamReader.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.ParserException;
+import com.google.android.exoplayer2.util.MimeTypes;
+import com.google.android.exoplayer2.util.ParsableByteArray;
+import com.google.android.exoplayer2.video.HevcConfig;
+
+import java.util.List;
+
+import ie.macinnes.htsp.HtspMessage;
+
+public class H265StreamReader extends PlainStreamReader {
+    private static final String TAG = H265StreamReader.class.getName();
+
+    @NonNull
+    @Override
+    protected Format buildFormat(int streamIndex, @NonNull HtspMessage stream) {
+        List<byte[]> initializationData = null;
+
+        if (stream.containsKey("meta")) {
+            try {
+                HevcConfig hevcConfig = HevcConfig.parse(new ParsableByteArray(stream.getByteArray("meta")));
+                initializationData = hevcConfig.initializationData;
+            } catch (ParserException e) {
+                Log.e(TAG, "Failed to parse H265 meta, discarding");
+            }
+        }
+
+        return Format.createVideoSampleFormat(
+                Integer.toString(streamIndex),
+                MimeTypes.VIDEO_H265,
+                null,
+                Format.NO_VALUE,
+                Format.NO_VALUE,
+                stream.getInteger("width"),
+                stream.getInteger("height"),
+                Format.NO_VALUE,
+                initializationData,
+                null);
+    }
+}

--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/Mpeg2AudioStreamReader.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/Mpeg2AudioStreamReader.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.util.MimeTypes;
+
+import ie.macinnes.htsp.HtspMessage;
+import ie.macinnes.tvheadend.TvhMappings;
+
+public class Mpeg2AudioStreamReader extends PlainStreamReader {
+
+    @NonNull
+    @Override
+    protected Format buildFormat(int streamIndex, @NonNull HtspMessage stream) {
+        int rate = Format.NO_VALUE;
+        if (stream.containsKey("rate")) {
+            rate = TvhMappings.sriToRate(stream.getInteger("rate"));
+        }
+
+        return Format.createAudioSampleFormat(
+                Integer.toString(streamIndex),
+                MimeTypes.AUDIO_MPEG_L2,
+                null,
+                Format.NO_VALUE,
+                Format.NO_VALUE,
+                stream.getInteger("channels", Format.NO_VALUE),
+                rate,
+                C.ENCODING_PCM_16BIT,
+                null,
+                null,
+                C.SELECTION_FLAG_AUTOSELECT,
+                stream.getString("language", "und")
+        );
+    }
+}

--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/Mpeg2VideoStreamReader.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/Mpeg2VideoStreamReader.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.util.MimeTypes;
+
+import ie.macinnes.htsp.HtspMessage;
+
+public class Mpeg2VideoStreamReader extends PlainStreamReader {
+
+    @NonNull
+    @Override
+    protected Format buildFormat(int streamIndex, @NonNull HtspMessage stream) {
+        return Format.createVideoSampleFormat(
+                Integer.toString(streamIndex),
+                MimeTypes.VIDEO_MPEG2,
+                null,
+                Format.NO_VALUE,
+                Format.NO_VALUE,
+                stream.getInteger("width"),
+                stream.getInteger("height"),
+                Format.NO_VALUE,
+                null,
+                null);
+    }
+}

--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/PlainStreamReader.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/PlainStreamReader.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.extractor.ExtractorOutput;
+import com.google.android.exoplayer2.extractor.TrackOutput;
+import com.google.android.exoplayer2.util.ParsableByteArray;
+
+import ie.macinnes.htsp.HtspMessage;
+
+/**
+ * A PlainStreamReader simply copies the raw bytes from muxpkt's over onto the track output
+ */
+abstract class PlainStreamReader implements StreamReader {
+    protected TrackOutput mTrackOutput;
+
+    @Override
+    public final void createTracks(@NonNull HtspMessage stream, @NonNull ExtractorOutput output) {
+        final int streamIndex = stream.getInteger("index");
+        mTrackOutput = output.track(streamIndex);
+        mTrackOutput.format(buildFormat(streamIndex, stream));
+    }
+
+    @Override
+    public final void consume(@NonNull final HtspMessage message) {
+        final long pts = message.getInteger("pts");
+        final byte[] payload = message.getByteArray("payload");
+
+        final ParsableByteArray pba = new ParsableByteArray(payload);
+
+        // TODO: Set Buffer Flag key frame based on frametype
+        // frametype   u32   required   Type of frame as ASCII value: 'I', 'P', 'B'
+        mTrackOutput.sampleData(pba, payload.length);
+        mTrackOutput.sampleMetadata(pts, C.BUFFER_FLAG_KEY_FRAME, payload.length, 0, null);
+    }
+
+    @NonNull
+    abstract protected Format buildFormat(int streamIndex, @NonNull HtspMessage stream);
+}

--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/StreamReader.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/StreamReader.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.exoplayer2.extractor.ExtractorOutput;
+
+import ie.macinnes.htsp.HtspMessage;
+
+public interface StreamReader {
+    void createTracks(HtspMessage stream, ExtractorOutput output);
+    void consume(@NonNull final HtspMessage message);
+}

--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/StreamReadersFactory.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/StreamReadersFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+public class StreamReadersFactory {
+    public StreamReader createStreamReader(String streamType) {
+        switch (streamType) {
+            // Video Stream Types
+            case "H264":
+                return new H264StreamReader();
+            case "HEVC":
+                return new H265StreamReader();
+            case "MPEG2VIDEO":
+                return new Mpeg2VideoStreamReader();
+            // Audio Stream Types
+            case "AAC":
+                return new AacStreamReader();
+            case "AC3":
+                return new Ac3StreamReader();
+            case "EAC3":
+                return new Eac3StreamReader();
+            case "MPEG2AUDIO":
+                return new Mpeg2AudioStreamReader();
+            case "VORBIS":
+                return new VorbisStreamReader();
+            // Text Stream Types
+            case "TEXTSUB":
+                return new TextsubStreamReader();
+            default:
+                return null;
+        }
+    }
+}

--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/TextsubStreamReader.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/TextsubStreamReader.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.extractor.ExtractorOutput;
+import com.google.android.exoplayer2.extractor.TrackOutput;
+import com.google.android.exoplayer2.util.MimeTypes;
+import com.google.android.exoplayer2.util.ParsableByteArray;
+import com.google.android.exoplayer2.util.Util;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import ie.macinnes.htsp.HtspMessage;
+
+public class TextsubStreamReader implements StreamReader {
+    private static final String TAG = TextsubStreamReader.class.getName();
+
+    /**
+     * A template for the prefix that must be added to each subrip sample. The 12 byte end timecode
+     * starting at {@link #SUBRIP_PREFIX_END_TIMECODE_OFFSET} is set to a dummy value, and must be
+     * replaced with the duration of the subtitle.
+     * <p>
+     * Equivalent to the UTF-8 string: "1\n00:00:00,000 --> 00:00:00,000\n".
+     */
+    private static final byte[] SUBRIP_PREFIX = new byte[] {49, 10, 48, 48, 58, 48, 48, 58, 48, 48,
+            44, 48, 48, 48, 32, 45, 45, 62, 32, 48, 48, 58, 48, 48, 58, 48, 48, 44, 48, 48, 48, 10};
+    /**
+     * A special end timecode indicating that a subtitle should be displayed until the next subtitle,
+     * or until the end of the media in the case of the last subtitle.
+     * <p>
+     * Equivalent to the UTF-8 string: "            ".
+     */
+    private static final byte[] SUBRIP_TIMECODE_EMPTY =
+            new byte[] {32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32};
+    /**
+     * The byte offset of the end timecode in {@link #SUBRIP_PREFIX}.
+     */
+    private static final int SUBRIP_PREFIX_END_TIMECODE_OFFSET = 19;
+    /**
+     * The length in bytes of a timecode in a subrip prefix.
+     */
+    private static final int SUBRIP_TIMECODE_LENGTH = 12;
+
+    protected TrackOutput mTrackOutput;
+
+    @Override
+    public final void createTracks(@NonNull HtspMessage stream, @NonNull ExtractorOutput output) {
+        final int streamIndex = stream.getInteger("index");
+        mTrackOutput = output.track(streamIndex);
+        mTrackOutput.format(buildFormat(streamIndex, stream));
+    }
+
+    @Override
+    public void consume(@NonNull final HtspMessage message) {
+        final long pts = message.getInteger("pts");
+        final long duration = message.getInteger("duration");
+        final byte[] payload = message.getByteArray("payload");
+
+        final int lengthWithPrefix = SUBRIP_PREFIX.length + payload.length;
+        final byte[] subsipSample = Arrays.copyOf(SUBRIP_PREFIX, lengthWithPrefix);
+
+        System.arraycopy(payload, 0, subsipSample, SUBRIP_PREFIX.length, payload.length);
+
+        setSubripSampleEndTimecode(subsipSample, duration);
+
+        mTrackOutput.sampleData(new ParsableByteArray(subsipSample), lengthWithPrefix);
+        mTrackOutput.sampleMetadata(pts, C.BUFFER_FLAG_KEY_FRAME, lengthWithPrefix, 0, null);
+    }
+
+    @NonNull
+    protected Format buildFormat(int streamIndex, @NonNull HtspMessage stream) {
+        return Format.createTextSampleFormat(
+                Integer.toString(streamIndex),
+                MimeTypes.APPLICATION_SUBRIP,
+                null,
+                Format.NO_VALUE,
+                C.SELECTION_FLAG_AUTOSELECT,
+                stream.getString("language", "und"),
+                null
+        );
+    }
+
+    private static void setSubripSampleEndTimecode(byte[] subripSample, long timeUs) {
+        byte[] timeCodeData;
+        if (timeUs == C.TIME_UNSET || timeUs == 0) {
+            timeCodeData = SUBRIP_TIMECODE_EMPTY;
+        } else {
+            int hours = (int) (timeUs / 3600000000L);
+            timeUs -= (hours * 3600000000L);
+            int minutes = (int) (timeUs / 60000000);
+            timeUs -= (minutes * 60000000);
+            int seconds = (int) (timeUs / 1000000);
+            timeUs -= (seconds * 1000000);
+            int milliseconds = (int) (timeUs / 1000);
+            timeCodeData = Util.getUtf8Bytes(String.format(Locale.US, "%02d:%02d:%02d,%03d", hours,
+                    minutes, seconds, milliseconds));
+        }
+
+        System.arraycopy(timeCodeData, 0, subripSample, SUBRIP_PREFIX_END_TIMECODE_OFFSET,
+                SUBRIP_TIMECODE_LENGTH);
+    }
+}

--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/VorbisStreamReader.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/VorbisStreamReader.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Kiall Mac Innes <kiall@macinnes.ie>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ie.macinnes.tvheadend.player.reader;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.util.MimeTypes;
+
+import ie.macinnes.htsp.HtspMessage;
+import ie.macinnes.tvheadend.TvhMappings;
+
+public class VorbisStreamReader extends PlainStreamReader {
+
+    @NonNull
+    @Override
+    protected Format buildFormat(int streamIndex, @NonNull HtspMessage stream) {
+        int rate = Format.NO_VALUE;
+        if (stream.containsKey("rate")) {
+            rate = TvhMappings.sriToRate(stream.getInteger("rate"));
+        }
+
+        return Format.createAudioSampleFormat(
+                Integer.toString(streamIndex),
+                MimeTypes.AUDIO_VORBIS,
+                null,
+                Format.NO_VALUE,
+                Format.NO_VALUE,
+                stream.getInteger("channels", Format.NO_VALUE),
+                rate,
+                C.ENCODING_PCM_16BIT,
+                null,
+                null,
+                C.SELECTION_FLAG_AUTOSELECT,
+                stream.getString("language", "und")
+        );
+    }
+}


### PR DESCRIPTION
Different stream types require more or less handling than others, for example,
TEXTSUB streams need to formatted into Subrip format (code for this taken from
the Apache 2.0 licenced ExoPlayer project). We'll also need to stip the Adts
framing from AAC audio streams, but this is yet to be implemented.