### PR TITLE
HtspDataSource should treat subscriptions too as end of input

### DIFF
--- a/app/src/main/java/ie/macinnes/tvheadend/player/HtspDataSource.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/HtspDataSource.java
@@ -121,7 +121,7 @@ public class HtspDataSource implements DataSource, Subscriber.Listener, Closeabl
             }
         }
 
-        if (!mIsOpen) {
+        if (!mIsOpen && mBuffer.remaining() == 0) {
             return C.RESULT_END_OF_INPUT;
         }
 
@@ -172,7 +172,8 @@ public class HtspDataSource implements DataSource, Subscriber.Listener, Closeabl
 
     @Override
     public void onSubscriptionStop(@NonNull HtspMessage message) {
-        serializeMessageToBuffer(message);
+        Log.i(TAG, "Received subscriptionStop");
+        mIsOpen = false;
     }
 
     @Override


### PR DESCRIPTION
Once we see a subscriptionStop message, we'll no longer get any more
messages related to this subscription. We need to close things off so
we don't sit in an infinite loop awaiting more data.