### PR TITLE
`mPendingChannelLogoFetches` stores `PendingChannelLogoFetch` objects…

### DIFF
--- a/app/src/main/java/ie/macinnes/tvheadend/sync/EpgSyncTask.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/sync/EpgSyncTask.java
@@ -496,7 +496,7 @@ public class EpgSyncTask implements HtspMessage.Listener, Authenticator.Listener
                 }
             }
 
-            mPendingChannelLogoFetches.remove(channelId);
+            mPendingChannelLogoFetches.remove(pendingChannelLogoFetch);
         }
     }
 


### PR DESCRIPTION
…, but this `remove()` call tries to remove an `int`. Most likely a bug, and this should be removing the `PendingChannelLogoFetch` that was just completed