### PR TITLE
An `int` divided by an `int` will always return an `int`, even when t…

### DIFF
--- a/app/src/main/java/ie/macinnes/tvheadend/player/reader/StreamReaderUtils.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/player/reader/StreamReaderUtils.java
@@ -24,7 +24,7 @@ public class StreamReaderUtils {
 
         if (frameDuration != Format.NO_VALUE) {
             // 1000000 = 1 second, in microseconds.
-            frameRate = 1000000 / frameDuration;
+            frameRate = 1000000 / (float) frameDuration;
         }
 
         return frameRate;


### PR DESCRIPTION
…he variable it is being stored to is a `float`. Explicitly casting one of the numbers to a `float` stops this.