### PR TITLE
Tuner count support added

### DIFF
--- a/app/src/main/java/ie/macinnes/tvheadend/Constants.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/Constants.java
@@ -46,6 +46,7 @@ public class Constants {
 
     // Advanced Preferences Keys and Values
     public static final String KEY_SHIELD_WORKAROUND_ENABLED = "shield_workaround_enabled";
+    public static final String KEY_TUNER_COUNT = "tuner_count";
     public static final String KEY_DEBUG_TEXT_VIEW_ENABLED = "debug_text_view_enabled";
     public static final String KEY_TIMESHIFT_ENABLED = "timeshift_enabled";
     public static final String KEY_DVR_ENABLED = "dvr_enabled";

--- a/app/src/main/java/ie/macinnes/tvheadend/tvinput/TvInputService.java
+++ b/app/src/main/java/ie/macinnes/tvheadend/tvinput/TvInputService.java
@@ -95,12 +95,21 @@ public class TvInputService extends android.media.tv.TvInputService {
 
         if (dvrEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             Log.i(TAG, "Enabling DVR Support");
+            int tuners;
+            try {
+                tuners = Integer.parseInt(mSharedPreferences.getString(
+                        Constants.KEY_TUNER_COUNT,
+                        getResources().getString(R.string.pref_default_tuner_count)));
+            }
+            catch (NumberFormatException e) {
+                tuners = 10;
+            }
 
             TvInputManager tim = (TvInputManager) getSystemService(Context.TV_INPUT_SERVICE);
             ComponentName componentName = new ComponentName(this, TvInputService.class);
             TvInputInfo tvInputInfo = new TvInputInfo.Builder(this, componentName)
                     .setCanRecord(true)
-                    .setTunerCount(10)
+                    .setTunerCount(tuners)
                     .build();
             tim.updateTvInputInfo(tvInputInfo);
         }

--- a/app/src/main/res/values/constants.xml
+++ b/app/src/main/res/values/constants.xml
@@ -34,5 +34,6 @@
     <bool name="pref_default_timeshift_enabled">false</bool>
     <bool name="pref_default_dvr_enabled">false</bool>
     <string name="pref_default_htsp_stream_profile">htsp</string>
+    <string name="pref_default_tuner_count">10</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -107,6 +107,14 @@
             android:summary="Stream profile to use for HTSP video"
             android:defaultValue="@string/pref_default_htsp_stream_profile" />
 
+        <EditTextPreference
+            android:key="tuner_count"
+            android:title="Tuner Count"
+            android:summary="Amount of tuners that TVHeadend can use"
+            android:defaultValue="@string/pref_default_tuner_count"
+            android:inputType="number"
+            android:digits="0123456789"/>
+
         <PreferenceScreen android:title="Crash Reporting Settings" android:key="crash_reporting_settings" android:persistent="false">
             <CheckBoxPreference android:key="acra.enable"
                                 android:title="@string/pref_disable_acra"


### PR DESCRIPTION
This means that people can now specify how many tuners they have, so that the TV Input Framework can detect conflicts and allow the user to resolve them.